### PR TITLE
[8.x] Add ignoreTrashed to Unique validation rule

### DIFF
--- a/src/Illuminate/Validation/Rules/Unique.php
+++ b/src/Illuminate/Validation/Rules/Unique.php
@@ -56,6 +56,19 @@ class Unique
 
         return $this;
     }
+    
+    /**
+     * Ignore trashed models during the unique check.
+     *
+     * @param  string|null  $deletedAtColumn
+     * @return $this
+     */
+    public function ignoreTrashed($deletedAtColumn = null)
+    {
+        $this->whereNull($deletedAtColumn ?? 'deleted_at');
+
+        return $this;
+    }
 
     /**
      * Convert the rule to a validation string.


### PR DESCRIPTION
I find myself adding `whereNull('deleted_at')` to the `Rule::unique()` quite often when working with models which can be soft deleted. This PR will add a simple helper to the unique validation rule. 

```php
// Before
[
  'email'=> [
    Rule::unique('users')->whereNull('deleted_at'),
  ],
];

// After
[
  'email'=> [
    Rule::unique('users')->ignoreTrashed(),
  ],
];
````